### PR TITLE
Updates C tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,6 +545,6 @@ To get started, simply fork this repo. Please refer to [CONTRIBUTING.md](CONTRIB
 - [Egghead.io](http://www.egghead.io/)
 - [Michael Herman's Blog](http://mherman.org/)
 - [Thinkster.io](http://thinkster.io)
-- [C Project Based Tutorials](https://www.reddit.com/r/C_Programming/comments/872rlt/c_project_based_tutorials/)
+- [C Project Based Tutorials](https://github.com/rby90/Project-Based-Tutorials-in-C)
 - [Enlight](https://enlight.nyc/)
 - [Hack Club Workshops](https://hackclub.com/workshops/)


### PR DESCRIPTION
## Description
Updates C Project Based Tutorials to link to https://github.com/rby90/Project-Based-Tutorials-in-C instead of https://www.reddit.com/r/C_Programming/comments/872rlt/c_project_based_tutorials

## Motivation and Context
If you read through the Reddit thread, the new GitHub link is more up to date.

## How Has This Been Tested?
I've looked through both links and compared the resource lists. The GitHub repo has the same resources and then some more.

## Types of changes
- [x] Content Update (change which fixes an issue or updates an already existing submission)
- [x] New Article (change which adds functionality)
- [ ] Documentation change

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have made checks to ensure URLs and other resources are valid
